### PR TITLE
Extend ConfigureWithoutCarrier to carrier changes

### DIFF
--- a/src/network/networkd-link.c
+++ b/src/network/networkd-link.c
@@ -3288,15 +3288,19 @@ int link_update(Link *link, sd_netlink_message *m) {
         if (carrier_gained) {
                 log_link_info(link, "Gained carrier");
 
-                r = link_carrier_gained(link);
-                if (r < 0)
-                        return r;
+                if (link->state != LINK_STATE_CONFIGURED || !link->network->configure_without_carrier) {
+                        r = link_carrier_gained(link);
+                        if (r < 0)
+                                return r;
+                }
         } else if (carrier_lost) {
                 log_link_info(link, "Lost carrier");
 
-                r = link_carrier_lost(link);
-                if (r < 0)
-                        return r;
+                if (link->state != LINK_STATE_CONFIGURED || !link->network->configure_without_carrier) {
+                        r = link_carrier_lost(link);
+                        if (r < 0)
+                              return r;
+                }
         }
 
         return 0;


### PR DESCRIPTION
Recently new [Network] option ConfigureWithoutCarrier was added which configures the link even if it has no carrier.

The idea is that IP addresses / routes are configured even if there is no carrier at the start of systemd-networkd service.

But in current case, if carrier is lost later (even for a moment) then this configuration (IP address / routes) are deleted. Which is obviously not what one wants. The purpose of the patch is that configuration exists regardless of carrier state.

This patch handles such cases. If link is already configured and if ConfigureWithoutCarrier is set then no action is taken on carrier gain or loss. (i.e. configuration remains as is)